### PR TITLE
Update Fetch.js

### DIFF
--- a/polyfill/Fetch.js
+++ b/polyfill/Fetch.js
@@ -40,6 +40,7 @@ class RNFetchBlobFetchPolyfill {
           promise = Blob.build(body).then((b) => {
             blobCache = b
             options.headers['Content-Type'] = 'multipart/form-data;boundary=' + b.multipartBoundary
+            options.headers['content-type'] = 'multipart/form-data;boundary=' + b.multipartBoundary
             return Promise.resolve(RNFetchBlob.wrap(b._ref))
           })
         }


### PR DESCRIPTION
https://github.com/joltup/rn-fetch-blob/issues/369

Resolution to the above issue, the RN code passes two instances of Content-Type, one containing capital letters and the other in lower case. 

The Android native code saves those options after applying .toLowerCase() on them.

The data in the lower case content-type overwrote the data in the Content-Type, and since the data on both the keys wasn't updated together at the fixed part of the code, it overwrote it with invalid data and caused the request to fail.